### PR TITLE
harvest logic updates

### DIFF
--- a/tests/Opt/test_clone.py
+++ b/tests/Opt/test_clone.py
@@ -111,7 +111,7 @@ def test_clone_harvest(
     strategy.harvest({"from": gov})
     assert new_plugin.harvestTrigger("100000000") == False
     sleep(chain, 20)
-    #ib.transfer(new_plugin.address, 100e18, {"from": whaleIb})
+    ib.transfer(new_plugin.address, 1e18, {"from": whaleIb})
     assert new_plugin.harvestTrigger("100000000") == True 
     before_bal = new_plugin.underlyingBalanceStored()
     before_stake = new_plugin.stakedBalance()
@@ -220,6 +220,7 @@ def test_clone(
         chain.sleep(15 * 30)
         chain.mine(waitBlock)
 
+        cloned_lender.harvest({"from":strategist})
         cloned_strategy.harvest({"from": strategist})
         chain.sleep(6 * 3600 + 1)  # to avoid sandwich protection
         chain.mine(1)

--- a/tests/Opt/test_rewards.py
+++ b/tests/Opt/test_rewards.py
@@ -32,8 +32,8 @@ def test_harvest(
     assert plugin.nav() == plugin.underlyingBalanceStored()
 
     assert plugin.harvestTrigger("100000000") == False
-    sleep(chain, 20)
-    #ib.transfer(plugin.address, 100e18, {"from": whaleIb})
+    sleep(chain, 60)
+    ib.transfer(plugin.address, 1e18, {"from": whaleIb})
     assert plugin.harvestTrigger("100000000") == True 
     
 

--- a/tests/Opt/test_usdc.py
+++ b/tests/Opt/test_usdc.py
@@ -33,6 +33,7 @@ def test_good_migration(
     chain.sleep(30 * 13)
     chain.mine(30)
 
+    
     strategy.harvest({"from": strategist})
 
     strategy_debt = vault.strategies(strategy)[6]  # totalDebt

--- a/tests/Opt/test_yswap.py
+++ b/tests/Opt/test_yswap.py
@@ -41,6 +41,8 @@ def test_yswap(
     with reverts():
         plugin.manualClaimAndDontSell({"from": rando})
 
+    plugin.setRewardStuff(plugin.minIbToSell(), 10, {"from": strategist})
+
     assert plugin.harvestTrigger("1") == True
 
     assert ib.balanceOf(plugin.address) == 0


### PR DESCRIPTION
changed harvest logic to just use beethoven for ib->weth swaps. Then uses Veledrome to go from weth->want. This means we should be able to autocompound most want tokens given suffecient liquidity in just the ib-eth pool